### PR TITLE
ADD: 레이아웃 초기 설정

### DIFF
--- a/src/routes/MainPage/HealthCharts/healthCharts.module.scss
+++ b/src/routes/MainPage/HealthCharts/healthCharts.module.scss
@@ -1,5 +1,6 @@
+@use '/src/styles/mixins/flexbox';
+
 .container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  @include flexbox.flexbox(center, center);
+  height: 100vh;
 }

--- a/src/routes/MainPage/HealthCharts/index.tsx
+++ b/src/routes/MainPage/HealthCharts/index.tsx
@@ -1,7 +1,11 @@
 import styles from './healthCharts.module.scss'
 
 const HealthCharts = () => {
-  return <div className={styles.container}>HealthCharts</div>
+  return (
+    <section className={styles.container}>
+      <h2>HealthCharts</h2>
+    </section>
+  )
 }
 
 export default HealthCharts

--- a/src/routes/MainPage/HealthManage/healthManage.module.scss
+++ b/src/routes/MainPage/HealthManage/healthManage.module.scss
@@ -1,5 +1,6 @@
+@use '/src/styles/mixins/flexbox';
+
 .container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  @include flexbox.flexbox(center, center);
+  height: 100vh;
 }

--- a/src/routes/MainPage/HealthManage/index.tsx
+++ b/src/routes/MainPage/HealthManage/index.tsx
@@ -1,7 +1,11 @@
 import styles from './healthManage.module.scss'
 
 const HealthManage = () => {
-  return <div className={styles.container}>HealthManage</div>
+  return (
+    <section className={styles.container}>
+      <h2>HealthManage</h2>
+    </section>
+  )
 }
 
 export default HealthManage

--- a/src/routes/MainPage/UserInfo/index.tsx
+++ b/src/routes/MainPage/UserInfo/index.tsx
@@ -1,7 +1,11 @@
 import styles from './userInfo.module.scss'
 
 const UserInfo = () => {
-  return <div className={styles.container}>UserInfo</div>
+  return (
+    <section className={styles.container}>
+      <h2>UserInfo</h2>
+    </section>
+  )
 }
 
 export default UserInfo

--- a/src/routes/MainPage/UserInfo/userInfo.module.scss
+++ b/src/routes/MainPage/UserInfo/userInfo.module.scss
@@ -1,5 +1,6 @@
+@use '/src/styles/mixins/flexbox';
+
 .container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  @include flexbox.flexbox(center, center);
+  height: 100vh;
 }

--- a/src/routes/MainPage/index.tsx
+++ b/src/routes/MainPage/index.tsx
@@ -1,7 +1,16 @@
+import UserInfo from './UserInfo'
+import HealthCharts from './HealthCharts'
+import HealthManage from './HealthManage'
 import styles from './mainPage.module.scss'
 
 const MainPage = () => {
-  return <div className={styles.container}>MainPage</div>
+  return (
+    <div className={styles.contentsContainer}>
+      <UserInfo />
+      <HealthCharts />
+      <HealthManage />
+    </div>
+  )
 }
 
 export default MainPage

--- a/src/routes/MainPage/mainPage.module.scss
+++ b/src/routes/MainPage/mainPage.module.scss
@@ -1,5 +1,4 @@
-.container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.contentsContainer {
+  height: 100%;
+  padding: 20px;
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,13 +6,16 @@ import MainPage from './MainPage'
 
 const App = () => {
   return (
-    <main className={styles.app}>
-      <Routes>
-        <Route path='/' element={<MainPage />} />
-        <Route path='login' element={<LoginPage />} />
-        <Route path='*' element={<div>404</div>} />
-      </Routes>
-    </main>
+    <div className={styles.container}>
+      <header>header</header>
+      <main className={styles.app}>
+        <Routes>
+          <Route path='/' element={<MainPage />} />
+          <Route path='login' element={<LoginPage />} />
+          <Route path='*' element={<div>404</div>} />
+        </Routes>
+      </main>
+    </div>
   )
 }
 

--- a/src/routes/routes.module.scss
+++ b/src/routes/routes.module.scss
@@ -2,8 +2,34 @@
 @use '/src/styles/mixins/flexbox';
 @use '/src/styles/mixins/responsive';
 
-.app {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+body {
+  @include flexbox.flexbox(center, center);
+  width: 100vw;
+  height: 100vh;
+  background: colors.$BG_COLOR;
+}
+
+.container {
+  width: 375px;
+  height: 720px;
+  overflow-y: scroll;
+  background: colors.$APP_BG;
+  border-radius: 20px;
+  box-shadow: 0 1px 4px colors.$APP_BOX_SHADOW;
+
+  header {
+    height: 80px;
+    padding: 20px;
+    background: colors.$MAIN_COLOR;
+    border-radius: 20px 20px 0 0;
+  }
+
+  main {
+    position: relative;
+    z-index: 20;
+    margin-top: -20px;
+    background: colors.$APP_BG;
+    border-radius: 20px;
+    box-shadow: 0 1px 4px rgba(colors.$BLACK, 0.5);
+  }
 }

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -22,3 +22,26 @@ $PINK: #ff2d55;
 $BIG_TITLE: #1f315b;
 $TASKS_TITLE: #8f99bf;
 $TASK_ITEM_TITLE: #4f566f;
+
+// health-app
+$BG_COLOR: #fafafa;
+$APP_BG: #ffffff;
+$APP_BOX_SHADOW: rgba(0, 0, 0, 16%);
+$MAIN_COLOR: #ffd300;
+$MAIN_TEXT_COLOR: #000000;
+$SUB_TEXT_COLOR: #666666;
+$BORDER_COLOR: #eeeeee;
+$SUB_YELLOW: #fff9d9;
+
+// card
+$NUMBER_COLOR: #444444;
+$GREEN_COLOR: #3cce3d;
+$PURPLE_COLOR: #c63ce7;
+$BLUE_COLOR: #529afc;
+$ORANGE_COLOR: #ffb850;
+$PINK_COLOR: #f9b5b4;
+$_COLOR: #8dd1c8;
+
+// tag
+$MAIN_TAG: #fee0d6;
+$SUB_TAG: #f1f1f1;


### PR DESCRIPTION
- 기본 레이아웃 설정해두었습니다.
- 스크롤시 헤더가 숨겨지게 했습니다.
- 컴포넌트는 section태그로 감싸주며 안에 제목태그를 넣습니다.
- 해당 앱에서 사용될 색상은 _colors.scss파일에 작성해 두었습니다.
(변수명은 임의로 해두었기 때문에 변경하셔도 괜찮습니다 :)
- 레이아웃 초기 설정이기 때문에 추후에 변경될 수 있습니다.

## 스크린 샷
![GG](https://user-images.githubusercontent.com/65527334/170631610-8cfdcdd8-1d39-4f6e-b1e2-826577150fee.gif)

